### PR TITLE
build: support Android 15 16 KB page-size alignment

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -59,7 +59,7 @@ android {
         jvmTarget = "1.8"
         freeCompilerArgs += listOf(
             "-Xjvm-default=all",
-            "-Xopt-in=kotlin.RequiresOptIn"
+            "-opt-in=kotlin.RequiresOptIn"
         )
     }
 
@@ -69,6 +69,11 @@ android {
             excludes += "/META-INF/INDEX.LIST"
             excludes += "/META-INF/io.netty.versions.properties"
             excludes += "META-INF/*.kotlin_module"
+        }
+        jniLibs {
+            // Store .so files uncompressed so the linker can mmap them; with AGP 8.5.1+
+            // uncompressed libs are zipaligned to 16 KB for Android 15 page-size support.
+            useLegacyPackaging = false
         }
     }
 }
@@ -126,6 +131,11 @@ dependencies {
     // Room
     implementation("androidx.room:room-runtime:2.6.1")
     annotationProcessor("androidx.room:room-compiler:2.6.1")
+
+    // Force a 16 KB page-size aligned DataStore native lib (libdatastore_shared_counter.so).
+    // Pulled transitively by Firebase Sessions / Play libs; older builds were 4 KB-aligned.
+    implementation("androidx.datastore:datastore-core:1.1.7")
+    implementation("androidx.datastore:datastore-core-okio:1.1.7")
 
     // Unit testing
     testImplementation("junit:junit:4.13.2")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,9 +1,11 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id("com.android.application") version "8.2.2" apply false
+    // AGP 8.6.x zipaligns uncompressed native libs to 16 KB (Android 15 page size)
+    // and clears the compileSdk 35 warning. Requires Gradle 8.7 (already set).
+    id("com.android.application") version "8.6.1" apply false
     id("com.google.gms.google-services") version "4.4.1" apply false
-    id("org.jetbrains.kotlin.android") version "1.8.20" apply false
-    id("com.google.firebase.crashlytics") version "2.9.9" apply false
+    id("org.jetbrains.kotlin.android") version "1.9.24" apply false
+    id("com.google.firebase.crashlytics") version "3.0.2" apply false
 }
 
 buildscript {
@@ -12,10 +14,10 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:8.2.2")
+        classpath("com.android.tools.build:gradle:8.6.1")
         classpath("com.google.gms:google-services:4.4.2")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.20")
-        classpath("com.google.firebase:firebase-crashlytics-gradle:2.9.9")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.24")
+        classpath("com.google.firebase:firebase-crashlytics-gradle:3.0.2")
     }
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem
Android 15 test devices warn: *"This app isn't 16 KB-compatible. APK alignment check failed"* on `libdatastore_shared_counter.so`.

Root cause: two things must hold for 16 KB compatibility:
1. Native `.so` files must be **packaged uncompressed** and **zipaligned to 16 KB** in the APK.
2. The `.so` itself must be **built with 16 KB ELF alignment** by its publisher.

Our build failed both: AGP 8.2.2 aligns to 4 KB, and the transitive DataStore lib (pulled by Firebase Sessions / Play libraries) was an older, 4 KB-aligned build.

## Changes
**`app/build.gradle.kts`**
- `packaging { jniLibs { useLegacyPackaging = false } }` — store `.so` uncompressed so they can be mmap'd and page-aligned
- Force a 16 KB-aligned DataStore:
  - `androidx.datastore:datastore-core:1.1.7`
  - `androidx.datastore:datastore-core-okio:1.1.7`
- `-Xopt-in` → `-opt-in` (the old flag is removed in Kotlin 1.9)

**`build.gradle.kts`**
- AGP `8.2.2` → `8.6.1` — zipaligns uncompressed native libs to **16 KB** and clears the `compileSdk 35` warning (Gradle 8.7 already in the wrapper, compatible)
- Kotlin `1.8.20` → `1.9.24`, Crashlytics Gradle `2.9.9` → `3.0.2` for AGP 8.6 compatibility

## Verify (locally, needs SDK + google-services.json)
```bash
./gradlew :app:assembleRelease
# Confirm 16 KB alignment of packaged .so files:
unzip -o app/build/outputs/apk/release/app-release.apk -d /tmp/apk
# Android SDK build-tools 35:
$ANDROID_HOME/build-tools/35.0.0/zipalign -c -P 16 -v 4 app-release.apk; echo "exit=$?"
# Or inspect ELF load alignment:
llvm-readelf -l /tmp/apk/lib/arm64-v8a/libdatastore_shared_counter.so | grep LOAD
```
Expected: `zipalign -c -P 16` passes; LOAD segments align to `0x4000` (16 KB).

## Notes
- This is a build-config change only; no app code changed.
- Full build not runnable in the cloud VM (no Android SDK / `google-services.json`) — please run the assemble/verify step locally.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a1c4cdce-969c-45a0-b5c8-897c684bb3ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a1c4cdce-969c-45a0-b5c8-897c684bb3ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

