### PR TITLE
feat: press back twice on Home to exit the app

### DIFF
--- a/app/src/main/java/com/khalil/DRACS/Activities/Activity_main.java
+++ b/app/src/main/java/com/khalil/DRACS/Activities/Activity_main.java
@@ -17,6 +17,7 @@ import android.widget.PopupMenu;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import androidx.activity.OnBackPressedCallback;
 import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.IntentSenderRequest;
 import androidx.activity.result.contract.ActivityResultContracts;
@@ -49,6 +50,8 @@ public class Activity_main extends AppCompatActivity {
     private static final String PREFS_NAME = "DRACS_Prefs";
     private static final String KEY_LARGE_FONT = "large_font";
     private static final String KEY_LAST_NAV_ITEM = "last_nav_item";
+    /** Window (ms) within which a second back press on Home exits the app. */
+    private static final long BACK_EXIT_INTERVAL_MS = 2000L;
 
     BottomNavigationView bottomNav;
     NavController navController;
@@ -65,6 +68,11 @@ public class Activity_main extends AppCompatActivity {
     private ActivityResultLauncher<IntentSenderRequest> activityResultLauncher;
     private ActivityResultLauncher<String> notificationPermissionLauncher;
     private Runnable pendingNotificationAction;
+
+    // Double-back-to-exit (only active on the Home destination)
+    private OnBackPressedCallback doubleBackToExitCallback;
+    private long lastBackPressedAt = 0L;
+    private Toast exitHintToast;
 
     @Override
     protected void attachBaseContext(Context newBase) {
@@ -208,9 +216,33 @@ public class Activity_main extends AppCompatActivity {
                     }
                 });
 
+        // Press back twice on Home to exit; enabled only while on the Home destination.
+        doubleBackToExitCallback = new OnBackPressedCallback(false) {
+            @Override
+            public void handleOnBackPressed() {
+                long now = System.currentTimeMillis();
+                if (now - lastBackPressedAt < BACK_EXIT_INTERVAL_MS) {
+                    if (exitHintToast != null) {
+                        exitHintToast.cancel();
+                    }
+                    finish();
+                    return;
+                }
+                lastBackPressedAt = now;
+                exitHintToast = Toast.makeText(
+                        Activity_main.this, R.string.press_back_again_to_exit, Toast.LENGTH_SHORT);
+                exitHintToast.show();
+            }
+        };
+        getOnBackPressedDispatcher().addCallback(this, doubleBackToExitCallback);
+
         navController.addOnDestinationChangedListener((controller, destination, arguments) -> {
             textTitle.setText(destination.getLabel());
             handleDestinationChange(destination.getId());
+
+            if (doubleBackToExitCallback != null) {
+                doubleBackToExitCallback.setEnabled(destination.getId() == R.id.home);
+            }
 
             if (destination.getId() == R.id.home) {
                 dracsicon.clearColorFilter();
@@ -465,6 +497,10 @@ public class Activity_main extends AppCompatActivity {
 
     @Override
     protected void onDestroy() {
+        if (exitHintToast != null) {
+            exitHintToast.cancel();
+            exitHintToast = null;
+        }
         super.onDestroy();
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -45,6 +45,7 @@
     <string name="settings_feedback_subject">ملاحظات حول تطبيق DRACS</string>
     <string name="settings_no_email_app">لا يوجد تطبيق بريد إلكتروني مثبت</string>
     <string name="settings_cache_cleared">تم مسح ذاكرة التخزين المؤقت بنجاح</string>
+    <string name="press_back_again_to_exit">اضغط مرة أخرى للخروج</string>
 
     <!-- Arabic-only splash -->
     <string name="splash_title_line1">المديرية الجهوية للفلاحة</string>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Adds the common "press back again to exit" behavior so users don't leave the app by an accidental single back press.

### Behavior
- On the **Home** destination, pressing back shows a toast **اضغط مرة أخرى للخروج**
- Pressing back **again within 2s** exits the app
- On all other screens, back keeps its current behavior (navigate to Home) — the exit callback is only enabled on Home

### Implementation
- `Activity_main` registers an `OnBackPressedCallback` via the `OnBackPressedDispatcher` (modern, predictive-back friendly — no deprecated `onBackPressed()`)
- The callback is enabled/disabled from the existing `addOnDestinationChangedListener` based on `R.id.home`, so it never interferes with content/settings/search back handling
- Toast is cancelled in `onDestroy` to avoid leaks
- New string: `press_back_again_to_exit`

## Test plan
- [ ] On Home, press back once → toast appears, app stays
- [ ] Press back again within 2s → app exits
- [ ] Wait >2s, press back again → toast again (no exit)
- [ ] From a content page / settings / search, back still returns Home (no exit toast)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a1c4cdce-969c-45a0-b5c8-897c684bb3ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a1c4cdce-969c-45a0-b5c8-897c684bb3ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

