### PR TITLE
fix: make regional map background match the theme (key out baked white)

### DIFF
--- a/app/src/main/java/com/khalil/DRACS/Fragments/home.java
+++ b/app/src/main/java/com/khalil/DRACS/Fragments/home.java
@@ -4,6 +4,9 @@ import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
+import android.content.res.Resources;
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
 import android.net.Uri;
 import android.os.Bundle;
 import android.text.TextUtils;
@@ -11,6 +14,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageButton;
+import android.widget.ImageView;
 import android.widget.TextView;
 import android.widget.Toast;
 
@@ -33,6 +37,11 @@ public class home extends Fragment {
 
     private static final String STATE_SELECTED_DPA = "state_selected_dpa";
     private static final long DETAIL_FADE_MS = 220L;
+    /** Pixels with every channel >= this are treated as the map's white background. */
+    private static final int WHITE_KEY_THRESHOLD = 238;
+
+    /** Cached transparent-background map; the asset ships with a baked white background. */
+    private static Bitmap transparentMapBitmap;
 
     private TextView dpaDetailName;
     private TextView dpaDetailAddress;
@@ -81,7 +90,56 @@ public class home extends Fragment {
         jeClick.setOnClickListener(v -> navigateTo(R.id.action_home_to_JE));
 
         bindDpaMap(view);
+        applyTransparentMap(view);
         selectDpa(selectedOffice, false);
+    }
+
+    /**
+     * The map asset ({@code ic_cart}) has a solid white background baked in, which shows as a
+     * light box on the dark card. Key out the near-white pixels once so the card background
+     * (light or dark) shows through and the map matches the current theme.
+     */
+    private void applyTransparentMap(@NonNull View root) {
+        ImageView mapView = root.findViewById(R.id.cart);
+        if (mapView == null) {
+            return;
+        }
+        if (transparentMapBitmap == null || transparentMapBitmap.isRecycled()) {
+            transparentMapBitmap = buildTransparentMap(getResources());
+        }
+        if (transparentMapBitmap != null) {
+            mapView.setImageBitmap(transparentMapBitmap);
+        }
+    }
+
+    @Nullable
+    private static Bitmap buildTransparentMap(@NonNull Resources res) {
+        BitmapFactory.Options opts = new BitmapFactory.Options();
+        opts.inPreferredConfig = Bitmap.Config.ARGB_8888;
+        Bitmap src = BitmapFactory.decodeResource(res, R.mipmap.ic_cart, opts);
+        if (src == null) {
+            return null;
+        }
+        Bitmap out = src.copy(Bitmap.Config.ARGB_8888, true);
+        src.recycle();
+        if (out == null) {
+            return null;
+        }
+        int w = out.getWidth();
+        int h = out.getHeight();
+        int[] pixels = new int[w * h];
+        out.getPixels(pixels, 0, w, 0, 0, w, h);
+        for (int i = 0; i < pixels.length; i++) {
+            int color = pixels[i];
+            int r = (color >> 16) & 0xFF;
+            int g = (color >> 8) & 0xFF;
+            int b = color & 0xFF;
+            if (r >= WHITE_KEY_THRESHOLD && g >= WHITE_KEY_THRESHOLD && b >= WHITE_KEY_THRESHOLD) {
+                pixels[i] = 0x00000000;
+            }
+        }
+        out.setPixels(pixels, 0, w, 0, 0, w, h);
+        return out;
     }
 
     @Override

--- a/app/src/main/res/drawable/bg_map_surface.xml
+++ b/app/src/main/res/drawable/bg_map_surface.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<shape xmlns:android="http://schemas.android.com/apk/res/android"
-    android:shape="rectangle">
-    <solid android:color="@color/map_surface" />
-    <corners android:radius="@dimen/radius_md" />
-</shape>

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -63,16 +63,17 @@
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/spacing_sm"
-                    android:background="@drawable/bg_map_surface"
+                    android:background="@android:color/transparent"
                     android:clipChildren="false"
                     android:clipToPadding="false"
-                    android:clipToOutline="true"
                     android:importantForAccessibility="yes"
                     android:layoutDirection="ltr"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@+id/map_label">
 
+                    <!-- src is overridden at runtime with a white-keyed (transparent bg) bitmap
+                         so the map blends with the card in both light and dark themes. -->
                     <ImageView
                         android:id="@+id/cart"
                         android:layout_width="0dp"

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -17,8 +17,6 @@
 
     <color name="background">#0F0F0D</color>
     <color name="card">#1A1A18</color>
-    <!-- Keep the map panel light so the illustration stays legible in dark mode -->
-    <color name="map_surface">#F5F5F3</color>
     <color name="foreground">#F5F5F3</color>
     <color name="muted_foreground">#BDBDBD</color>
     <color name="border">#2A2A27</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -27,8 +27,6 @@
     <!-- Backgrounds -->
     <color name="background">#FAFAF8</color>
     <color name="card">#FFFFFF</color>
-    <!-- Light backing for the (white-baked) regional map illustration; light in both themes -->
-    <color name="map_surface">#FFFFFF</color>
     <color name="foreground">#1A1A18</color>
     <color name="muted_foreground">#6B6B68</color>
     <color name="border">#E5E5E2</color>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem
The map asset `mipmap/ic_cart.png` has a **solid white background baked into the pixels**. On the dark card this showed as a light box. The previous attempt only rounded the corners / added a light panel — the white is in the bitmap itself, so it never matched a dark theme. There's no transparent/vector version of the asset in the project.

## Fix
Key out the near-white background **at runtime** so the card (light or dark) shows through and the map blends with the current theme:
- `home.buildTransparentMap()` decodes `ic_cart` to `ARGB_8888`, sets pixels with all channels ≥ 238 to transparent, and caches the result (static, processed once)
- Applied via `setImageBitmap` in `onViewCreated`
- Reverted the light-surface panel: `map_container` background is transparent again; removed `bg_map_surface` drawable and the `map_surface` colors

## Notes / trade-offs
- Threshold 238 targets the white "sea"/margins; the colored provinces and black labels are well below it, so they're preserved.
- If any thin interior white borders become transparent, provinces remain distinguishable by their fill colors.
- Cleanest long-term fix is still a proper **transparent PNG or vector** of the map — if one is exported into `res/drawable/`, we can drop the runtime keying and just set `android:src`.

## Test plan
- [ ] Dark theme: map background matches the dark card (no white box)
- [ ] Light theme: map still looks correct
- [ ] Pins remain aligned over provinces; DRA (El Jadida) default selection intact
- [ ] Rotate device: no flicker/leak (bitmap cached)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a1c4cdce-969c-45a0-b5c8-897c684bb3ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a1c4cdce-969c-45a0-b5c8-897c684bb3ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

